### PR TITLE
Fix param converter that could throw error

### DIFF
--- a/src/Controller/PlatformController.php
+++ b/src/Controller/PlatformController.php
@@ -57,8 +57,12 @@ class PlatformController extends AbstractController
     }
 
     #[Route('/back-office/platform/{id}/edit', name: 'app_platform_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, Platform $platform, EntityManagerInterface $entityManager, UserInterface $user): Response
+    public function edit(Request $request, Platform $platform = null, EntityManagerInterface $entityManager, UserInterface $user): Response
     {
+        if (null === $platform) {
+            throw $this->createNotFoundException('Platform not found.');
+        }
+
         $form = $this->createForm(PlatformType::class, $platform);
         $form->handleRequest($request);
 
@@ -77,8 +81,12 @@ class PlatformController extends AbstractController
     }
 
     #[Route('/back-office/platform/{id}/delete', name: 'app_platform_delete', methods: ['POST'])]
-    public function delete(Request $request, Platform $platform, EntityManagerInterface $entityManager): Response
+    public function delete(Request $request, Platform $platform = null, EntityManagerInterface $entityManager): Response
     {
+        if (null === $platform) {
+            throw $this->createNotFoundException('Platform not found.');
+        }
+        
         if ($this->isCsrfTokenValid('delete'.$platform->getId(), $request->request->get('_token'))) {
             $entityManager->remove($platform);
             $entityManager->flush();

--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -46,8 +46,12 @@ class TagController extends AbstractController
     }
 
     #[Route('/{id}/edit', name: 'app_tag_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, Tag $tag, EntityManagerInterface $entityManager, UserInterface $user): Response
+    public function edit(Request $request, Tag $tag = null, EntityManagerInterface $entityManager, UserInterface $user): Response
     {
+        if (null === $tag) {
+            throw $this->createNotFoundException('Tag not found.');
+        }
+
         $form = $this->createForm(TagType::class, $tag);
         $form->handleRequest($request);
 
@@ -66,8 +70,12 @@ class TagController extends AbstractController
     }
 
     #[Route('/{id}/delete', name: 'app_tag_delete', methods: ['POST'])]
-    public function delete(Request $request, Tag $tag, EntityManagerInterface $entityManager): Response
+    public function delete(Request $request, Tag $tag = null, EntityManagerInterface $entityManager): Response
     {
+        if (null === $tag) {
+            throw $this->createNotFoundException('Tag not found.');
+        }
+        
         if ($this->isCsrfTokenValid('delete'.$tag->getId(), $request->request->get('_token'))) {
             $entityManager->remove($tag);
             $entityManager->flush();


### PR DESCRIPTION
Add default value when param converter is used, then throw not found exception if value is still null